### PR TITLE
Support reading config from environment variables

### DIFF
--- a/luoxu/util.py
+++ b/luoxu/util.py
@@ -3,6 +3,8 @@ from enum import Enum, auto
 
 import tomli
 from telethon import TelegramClient
+import copy
+import os
 
 def format_name(user) -> str:
   if user is None:
@@ -33,9 +35,84 @@ def run_until_sigint(fu):
       pass
     print('Cancelled.')
 
+config_schema = {
+    'telegram': {
+        'api_id': 'int',
+        'api_hash': 'str',
+        'account': 'str',
+        'session_db': 'str',
+        'ipv6': 'str',
+        'proxy': 'strs',
+        'mark_as_read': 'bool',
+        'index_groups': 'strs',
+        'ocr_ignore_groups': 'strs',
+    },
+    'database': {
+        'url': 'str',
+        'first_year': 'int',
+        'ocr_url': 'str',
+        'ocr_socket': 'str',
+    },
+    'web': {
+        'listen_host': 'str',
+        'listen_port': 'int',
+        'cache_dir': 'str',
+        'default_avatar': 'str',
+        'ghost_avatar': 'str',
+        'prefix': 'str',
+        'origins': 'strs',
+    },
+    'plugin': {
+        'wordcloud': {
+            'enabled': 'bool',
+            'url': 'bool'
+        },
+        'adminapi': {
+            'enabled': 'bool',
+            'port': 'int'
+        }
+    }
+}
+
 def load_config(file):
-  with open(file, 'rb') as f:
-    return tomli.load(f)
+  def merge_env(origin: dict[str, any]) -> dict[str, any]:
+    def get_env(name: str, typ: str) -> any:
+      if name not in os.environ:
+        return None
+      v = os.environ[name]
+      if typ == 'str':
+        return v
+      if typ == 'int':
+        return int(v)
+      if typ == 'bool':
+        return v.lower() == 'true'
+      if typ == 'strs':
+        return v.split(',')
+      raise ValueError(f'unknown type {typ}')
+    def f(x: any, ctx: list[str]) -> any:
+      if isinstance(x, dict):
+        return {k: y for k, v in x.items() if (y := f(v, ctx + [k.upper()]))}
+      if isinstance(x, str):
+        return get_env('_'.join(ctx), x)
+      raise ValueError(f'unknown value {x}')
+
+    def g(a: dict[str, any], b: dict[str, any]) -> dict[str, any]:
+      r = copy.deepcopy(a)
+      for k, v in b.items():
+        old = a.get(k)
+        if isinstance(old, dict) and isinstance(v, dict):
+          r[k] = g(old, v)
+        else:
+          r[k] = copy.deepcopy(v)
+      return r
+    new = f(config_schema, [])
+    return g(origin, new)
+  if os.path.isfile(file):
+    with open(file, 'rb') as f:
+      return merge_env(tomli.load(f))
+  else:
+    print(f'{file} does not exist, using env vars only')
+    return merge_env({})
 
 class UpdateLoaded(Enum):
   update_none = auto()


### PR DESCRIPTION
从环境变量传入的配置可覆盖配置文件中的对应项，这将有助于模块化配置。设置以下环境变量可达到与配置文件示例的相同效果：

```sh
TELEGRAM_API_ID="10000" \
TELEGRAM_API_HASH="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
TELEGRAM_ACCOUNT="+1234567890" \
TELEGRAM_SESSION_DB="mybot" \
TELEGRAM_PROXY="127.0.0.1,1080" \
TELEGRAM_INDEX_GROUPS="1000000000, 1000000001" \
DATABASE_URL="postgresql:///luoxu" \
WEB_LISTEN_HOST="localhost" \
WEB_LISTEN_PORT=9008 \
WEB_PREFIX="/luoxu" \
WEB_CACHE_DIR="cache" \
WEB_DEFAULT_AVATAR="nobody.jpg" \
WEB_GHOST_AVATAR="ghost.jpg" \
WEB_ORIGINS="http://localhost"
```