### PR TITLE
添加非公开索引支持

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -19,6 +19,10 @@ index_groups = [
 #   "@group1",
 #   "1000000000",
 # ]
+# auth_enable_groups = [
+#   "1000000000",
+# ]
+# auth_expire = 3600 # 1 hour
 
 [database]
 url = "postgresql:///luoxu"
@@ -37,4 +41,8 @@ ghost_avatar = "ghost.jpg"
 origins = [
   "http://localhost",
 ]
+
+# [plugin.auth]
+# enabled = true
+# web_url = "http://localhost"
 # vim: se ft=toml:

--- a/config.toml.example
+++ b/config.toml.example
@@ -23,6 +23,7 @@ index_groups = [
 #   "1000000000",
 # ]
 # auth_expire = 3600 # 1 hour
+# auth_bot_token = "1231312313:xxxxxxx"
 
 [database]
 url = "postgresql:///luoxu"

--- a/luoxu/__main__.py
+++ b/luoxu/__main__.py
@@ -78,6 +78,8 @@ class Indexer:
     ttl = int(tg_config.get('auth_expire', 3600))
     self.token_manager = TokenManager(ttl)
 
+    self.auth_bot_token = tg_config.get('auth_bot_token', None)
+
     await client.start(tg_config['account'])
     index_group_ids = []
     ocr_ignore_group_ids = []
@@ -107,6 +109,8 @@ class Indexer:
 
     self.ocr_ignore_group_ids = ocr_ignore_group_ids
     self.auth_enable_group_ids = auth_enable_group_ids
+    if self.auth_enable_group_ids != [] and self.auth_bot_token is None:
+      raise ValueError('auth_enable_groups is not empty but auth_bot_token is not set')
     client.add_event_handler(self.on_message, events.NewMessage(chats=index_group_ids))
     client.add_event_handler(self.on_message, events.MessageEdited(chats=index_group_ids))
 
@@ -122,8 +126,9 @@ class Indexer:
       os.path.abspath(web_config['ghost_avatar']),
       prefix = web_config['prefix'],
       origins = web_config['origins'],
-      auth_enable_groups = auth_enable_group_ids,
+      auth_enable_groups = self.auth_enable_group_ids,
       token_manager = self.token_manager,
+      auth_bot_token = self.auth_bot_token,
     )
     runner = web.AppRunner(app)
     await runner.setup()

--- a/luoxu/__main__.py
+++ b/luoxu/__main__.py
@@ -109,8 +109,6 @@ class Indexer:
 
     self.ocr_ignore_group_ids = ocr_ignore_group_ids
     self.auth_enable_group_ids = auth_enable_group_ids
-    if self.auth_enable_group_ids != [] and self.auth_bot_token is None:
-      raise ValueError('auth_enable_groups is not empty but auth_bot_token is not set')
     client.add_event_handler(self.on_message, events.NewMessage(chats=index_group_ids))
     client.add_event_handler(self.on_message, events.MessageEdited(chats=index_group_ids))
 

--- a/luoxu/__main__.py
+++ b/luoxu/__main__.py
@@ -13,6 +13,7 @@ from aiohttp import web
 from .db import PostgreStore
 from .group import GroupHistoryIndexer
 from .util import load_config, UpdateLoaded, create_client
+from .auth import TokenManager
 from . import web as myweb
 from .ctxvars import msg_source
 
@@ -74,28 +75,13 @@ class Indexer:
     await db.setup()
     self.dbstore = db
 
-    web_config = config['web']
-    cache_dir = web_config['cache_dir']
-    os.makedirs(cache_dir, exist_ok=True)
-    app = myweb.setup_app(
-      db, client,
-      os.path.abspath(cache_dir),
-      os.path.abspath(web_config['default_avatar']),
-      os.path.abspath(web_config['ghost_avatar']),
-      prefix = web_config['prefix'],
-      origins = web_config['origins'],
-    )
-    runner = web.AppRunner(app)
-    await runner.setup()
-    site = web.TCPSite(
-      runner,
-      web_config['listen_host'], web_config['listen_port'],
-    )
-    await site.start()
+    ttl = int(tg_config.get('auth_expire', 3600))
+    self.token_manager = TokenManager(ttl)
 
     await client.start(tg_config['account'])
     index_group_ids = []
     ocr_ignore_group_ids = []
+    auth_enable_group_ids = []
     group_entities = []
     dialogs = None
     for g in tg_config['index_groups']:
@@ -113,14 +99,39 @@ class Indexer:
       if g in tg_config.get('ocr_ignore_groups', ()):
         ocr_ignore_group_ids.append(group.id)
 
+      if g in tg_config.get('auth_enable_groups', ()):
+        auth_enable_group_ids.append(group.id)
+
       index_group_ids.append(group.id)
       group_entities.append(group)
 
     self.ocr_ignore_group_ids = ocr_ignore_group_ids
+    self.auth_enable_group_ids = auth_enable_group_ids
     client.add_event_handler(self.on_message, events.NewMessage(chats=index_group_ids))
     client.add_event_handler(self.on_message, events.MessageEdited(chats=index_group_ids))
 
     await self.load_plugins(client)
+
+    web_config = config['web']
+    cache_dir = web_config['cache_dir']
+    os.makedirs(cache_dir, exist_ok=True)
+    app = myweb.setup_app(
+      db, client,
+      os.path.abspath(cache_dir),
+      os.path.abspath(web_config['default_avatar']),
+      os.path.abspath(web_config['ghost_avatar']),
+      prefix = web_config['prefix'],
+      origins = web_config['origins'],
+      auth_enable_groups = auth_enable_group_ids,
+      token_manager = self.token_manager,
+    )
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(
+      runner,
+      web_config['listen_host'], web_config['listen_port'],
+    )
+    await site.start()
 
     try:
       while True:

--- a/luoxu/auth.py
+++ b/luoxu/auth.py
@@ -1,0 +1,29 @@
+import time
+import secrets
+
+class TokenManager:
+    def __init__(self, ttl):
+        self.tokens = {}
+        self.ttl = ttl
+
+    def add_token(self, gid):
+        if gid in self.tokens and self.tokens[gid]["expiry"] > time.time():
+            return self.tokens[gid]["token"]
+
+        token = secrets.token_urlsafe(8)
+        expiry_time = time.time() + self.ttl
+        self.tokens[gid] = {"token": token, "expiry": expiry_time}
+
+        return token
+
+
+    def remove_expired_tokens(self):
+        current_time = time.time()
+        self.tokens = {gid: data for gid, data in self.tokens.items() if data["expiry"] > current_time}
+
+    def is_valid(self, gid, token):
+        self.remove_expired_tokens()
+        token_data = self.tokens.get(gid)
+        if token_data and token_data["token"] == token:
+            return True
+        return False

--- a/luoxu/auth.py
+++ b/luoxu/auth.py
@@ -1,29 +1,47 @@
-import time
 import secrets
+import hashlib
+import hmac
+import time
+
+from .lib.expiringdict import ExpiringDict
 
 class TokenManager:
     def __init__(self, ttl):
-        self.tokens = {}
-        self.ttl = ttl
+        self._token_dict = ExpiringDict(default_ttl=ttl)
 
-    def add_token(self, gid):
-        if gid in self.tokens and self.tokens[gid]["expiry"] > time.time():
-            return self.tokens[gid]["token"]
+    def add_token(self, group_id):
+        self._token_dict.expire()
+        if existing_token := self._token_dict.get(group_id):
+            return existing_token
+        new_token = secrets.token_urlsafe(8)
+        self._token_dict[group_id] = new_token
+        return new_token
 
-        token = secrets.token_urlsafe(8)
-        expiry_time = time.time() + self.ttl
-        self.tokens[gid] = {"token": token, "expiry": expiry_time}
+    def is_valid(self, group_id, token):
+        self._token_dict.expire()
+        if not (existing_token := self._token_dict.get(group_id)):
+            return False
+        # hmac.compare_digest?
+        return existing_token == token
 
-        return token
+def Verify_telegram_oauth(bot_token, data:dict):
+    hash_str = ""
+    text_list = []
+    for key, value in data.items():
+        if key == "hash":
+            hash_str = value
+        else:
+            text_list.append(f"{key}={value}")
+    check_str = "\n".join(sorted(text_list))
+    try:
+        if time.time() - int(data['auth_date']) > 86400:
+            return None
+    except ValueError:
+        return None
 
-
-    def remove_expired_tokens(self):
-        current_time = time.time()
-        self.tokens = {gid: data for gid, data in self.tokens.items() if data["expiry"] > current_time}
-
-    def is_valid(self, gid, token):
-        self.remove_expired_tokens()
-        token_data = self.tokens.get(gid)
-        if token_data and token_data["token"] == token:
-            return True
-        return False
+    secret_key = hashlib.sha256(bot_token.encode()).digest()
+    hmac_hash = hmac.new(secret_key, check_str.encode(), hashlib.sha256).hexdigest()
+    # hmac.compare_digest?
+    if not (hmac_hash == hash_str):
+        return None
+    return data['id']

--- a/luoxu/auth.py
+++ b/luoxu/auth.py
@@ -2,6 +2,8 @@ import secrets
 import hashlib
 import hmac
 import time
+import json
+import base64
 
 from .lib.expiringdict import ExpiringDict
 
@@ -24,7 +26,13 @@ class TokenManager:
         # hmac.compare_digest?
         return existing_token == token
 
-def Verify_telegram_oauth(bot_token, data:dict):
+def Verify_telegram_oauth(bot_token, auth_str):
+    padding = '=' * (4 - len(auth_str) % 4)
+    auth_str += padding
+    try:
+      data = json.loads(base64.urlsafe_b64decode(auth_str).decode('utf-8'))
+    except:
+      return None
     hash_str = ""
     text_list = []
     for key, value in data.items():
@@ -34,14 +42,14 @@ def Verify_telegram_oauth(bot_token, data:dict):
             text_list.append(f"{key}={value}")
     check_str = "\n".join(sorted(text_list))
     try:
-        if time.time() - int(data['auth_date']) > 86400:
+        if time.time() - int(data['auth_date']) > 60 * 60 * 24 * 30:
             return None
-    except ValueError:
+    except (ValueError, KeyError, TypeError):
         return None
 
     secret_key = hashlib.sha256(bot_token.encode()).digest()
     hmac_hash = hmac.new(secret_key, check_str.encode(), hashlib.sha256).hexdigest()
     # hmac.compare_digest?
-    if not (hmac_hash == hash_str):
-        return None
+    if hmac_hash != hash_str:
+      return None
     return data['id']

--- a/luoxu/auth.py
+++ b/luoxu/auth.py
@@ -26,7 +26,7 @@ class TokenManager:
         # hmac.compare_digest?
         return existing_token == token
 
-def Verify_telegram_oauth(bot_token, auth_str):
+def verify_telegram_oauth(bot_token, auth_str):
     padding = '=' * (4 - len(auth_str) % 4)
     auth_str += padding
     try:

--- a/luoxu/auth.py
+++ b/luoxu/auth.py
@@ -31,7 +31,7 @@ def verify_telegram_oauth(bot_token, auth_str):
     auth_str += padding
     try:
       data = json.loads(base64.urlsafe_b64decode(auth_str).decode('utf-8'))
-    except:
+    except Exception:
       return None
     hash_str = ""
     text_list = []

--- a/luoxu/auth.py
+++ b/luoxu/auth.py
@@ -23,8 +23,7 @@ class TokenManager:
         self._token_dict.expire()
         if not (existing_token := self._token_dict.get(group_id)):
             return False
-        # hmac.compare_digest?
-        return existing_token == token
+        return hmac.compare_digest(existing_token, token)
 
 def verify_telegram_oauth(bot_token, auth_str):
     padding = '=' * (4 - len(auth_str) % 4)
@@ -49,7 +48,6 @@ def verify_telegram_oauth(bot_token, auth_str):
 
     secret_key = hashlib.sha256(bot_token.encode()).digest()
     hmac_hash = hmac.new(secret_key, check_str.encode(), hashlib.sha256).hexdigest()
-    # hmac.compare_digest?
-    if hmac_hash != hash_str:
-      return None
-    return data['id']
+    if hmac.compare_digest(hmac_hash, hash_str):
+      return data['id']
+    return None

--- a/luoxu/types.py
+++ b/luoxu/types.py
@@ -7,6 +7,7 @@ class SearchQuery(NamedTuple):
   sender: Optional[str]
   start: Optional[datetime.datetime]
   end: Optional[datetime.datetime]
+  token: Optional[str]
 
 class GroupNotFound(Exception):
   def __init__(self, group):

--- a/luoxu/web.py
+++ b/luoxu/web.py
@@ -9,6 +9,7 @@ from aiohttp import web
 from telethon.tl.types import User, ChatPhotoEmpty
 from telethon.errors.rpcerrorlist import ChannelPrivateError, UserNotParticipantError
 from telethon import functions
+from async_lru import alru_cache
 
 from . import util
 from .types import SearchQuery, GroupNotFound
@@ -103,6 +104,7 @@ class GroupsHandler(BaseHandler):
     self.token_manager = token_manager
     self.auth_bot_token = auth_bot_token
 
+  @alru_cache(maxsize=None, ttl=86400)
   async def user_in_group(self, group_id, user_id):
     try:
       res = await self.client(functions.channels.GetParticipantRequest(

--- a/luoxu/web.py
+++ b/luoxu/web.py
@@ -4,8 +4,6 @@ import logging
 from html import escape as htmlescape
 import re
 import time
-import json
-import base64
 
 from aiohttp import web
 from telethon.tl.types import User, ChatPhotoEmpty
@@ -101,46 +99,51 @@ class GroupsHandler(BaseHandler):
   def __init__(self, dbconn, client, auth_enable_groups, token_manager, auth_bot_token):
     super().__init__(dbconn)
     self.client = client
-    self.auth_enable_groups = auth_enable_groups
+    self.auth_enable_groups = set(auth_enable_groups)
     self.token_manager = token_manager
     self.auth_bot_token = auth_bot_token
 
+  async def user_in_group(self, group_id, user_id):
+    try:
+      res = await self.client(functions.channels.GetParticipantRequest(
+          channel=group_id,
+          participant=user_id
+      ))
+      return True
+    except UserNotParticipantError:
+      return False
+    except:
+      logger.exception('failed to get participant')
+      return False
+
   async def _get(self, request):
-    auth_str = request.query.get('auth', '')
+    group_id = request.query.get('g')
+    token = request.query.get('token')
     user_id = None
-    if self.auth_bot_token and auth_str:
-      try:
-        padding = '=' * (4 - len(auth_str) % 4)
-        auth_str += padding
-        data = json.loads(base64.urlsafe_b64decode(auth_str).decode('utf-8'))
-        user_id = Verify_telegram_oauth(self.auth_bot_token, data)
-      except:
-        user_id = None
+    if auth_str := request.query.get('auth'):
+      if not (user_id := Verify_telegram_oauth(self.auth_bot_token, auth_str)):
+        raise web.HTTPForbidden
+
     groups = await self.dbconn.get_groups()
     gs = []
     for g in groups:
-      if g['group_id'] not in self.auth_enable_groups:
-        gs.append({
-          'group_id': str(g['group_id']),
+      gid = g['group_id']
+      is_private = gid in self.auth_enable_groups
+      has_access = False
+      if is_private:
+        has_access = (
+            (user_id and await self.user_in_group(gid, user_id)) or 
+            (token and group_id == str(gid) and self.token_manager.is_valid(gid, token))
+        )
+      if not is_private or has_access:
+        item = {
+          'group_id': str(gid),
           'name': g['name'],
           'pub_id': g['pub_id'],
-        })
-      elif self.client and user_id:
-        try:
-          res = await self.client(functions.channels.GetParticipantRequest(
-              channel=g['group_id'],
-              participant=user_id
-          ))
-          gs.append({
-            'group_id': str(g['group_id']),
-            'name': g['name'],
-            'pub_id': g['pub_id'],
-            'token': self.token_manager.add_token(g['group_id']),
-          })
-        except UserNotParticipantError:
-          pass
-        except:
-          logger.exception('failed to get participant')
+        }
+        if is_private:
+          item['token'] = self.token_manager.add_token(gid)
+        gs.append(item)
 
     gs.sort(key=lambda g: g['name'])
     return web.json_response({

--- a/luoxu/web.py
+++ b/luoxu/web.py
@@ -44,11 +44,21 @@ def html_or_text(m):
   return ' '
 
 class SearchHandler(BaseHandler):
+  def __init__(self, dbconn, auth_enable_groups, token_manager):
+    super().__init__(dbconn)
+    self.auth_enable_groups = auth_enable_groups
+    self.token_manager = token_manager
+
   async def _get(self, request):
     try:
       q = self._parse_query(request.query)
     except Exception:
       raise web.HTTPBadRequest
+    if q.group in self.auth_enable_groups:
+      if not q.token:
+        raise web.HTTPUnauthorized
+      if not self.token_manager.is_valid(q.group, q.token):
+        raise web.HTTPForbidden
     try:
       groupinfo, messages = await self.dbconn.search(q)
     except GroupNotFound:
@@ -75,12 +85,13 @@ class SearchHandler(BaseHandler):
     terms = query.get('q')
     sender = int(query.get('sender', 0))
     start = query.get('start')
+    token = query.get('token', '')
     if start:
       start = util.fromtimestamp(int(start))
     end = query.get('end')
     if end:
       end = util.fromtimestamp(int(end))
-    return SearchQuery(group, terms, sender, start, end)
+    return SearchQuery(group, terms, sender, start, end, token)
 
 class GroupsHandler(BaseHandler):
   async def _get(self, request):
@@ -174,10 +185,12 @@ def setup_app(
   *,
   prefix = '',
   origins = (),
+  auth_enable_groups = (),
+  token_manager = None,
 ):
   app = web.Application()
   app['origins'] = origins
-  app.router.add_get(f'{prefix}/search', SearchHandler(dbconn).get)
+  app.router.add_get(f'{prefix}/search', SearchHandler(dbconn, auth_enable_groups, token_manager).get)
   app.router.add_get(f'{prefix}/groups', GroupsHandler(dbconn).get)
   app.router.add_get(f'{prefix}/names', NamesHandler(dbconn).get)
 

--- a/luoxu/web.py
+++ b/luoxu/web.py
@@ -112,7 +112,7 @@ class GroupsHandler(BaseHandler):
       return True
     except UserNotParticipantError:
       return False
-    except:
+    except Exception:
       logger.exception('failed to get participant')
       return False
 

--- a/luoxu/web.py
+++ b/luoxu/web.py
@@ -12,7 +12,7 @@ from telethon import functions
 
 from . import util
 from .types import SearchQuery, GroupNotFound
-from .auth import Verify_telegram_oauth
+from .auth import verify_telegram_oauth
 
 logger = logging.getLogger(__name__)
 
@@ -121,7 +121,7 @@ class GroupsHandler(BaseHandler):
     token = request.query.get('token')
     user_id = None
     if auth_str := request.query.get('auth'):
-      if not (user_id := Verify_telegram_oauth(self.auth_bot_token, auth_str)):
+      if not (user_id := verify_telegram_oauth(self.auth_bot_token, auth_str)):
         raise web.HTTPForbidden
 
     groups = await self.dbconn.get_groups()

--- a/luoxu/web.py
+++ b/luoxu/web.py
@@ -4,13 +4,17 @@ import logging
 from html import escape as htmlescape
 import re
 import time
+import json
+import base64
 
 from aiohttp import web
 from telethon.tl.types import User, ChatPhotoEmpty
-from telethon.errors.rpcerrorlist import ChannelPrivateError
+from telethon.errors.rpcerrorlist import ChannelPrivateError, UserNotParticipantError
+from telethon import functions
 
 from . import util
 from .types import SearchQuery, GroupNotFound
+from .auth import Verify_telegram_oauth
 
 logger = logging.getLogger(__name__)
 
@@ -94,21 +98,72 @@ class SearchHandler(BaseHandler):
     return SearchQuery(group, terms, sender, start, end, token)
 
 class GroupsHandler(BaseHandler):
+  def __init__(self, dbconn, client, auth_enable_groups, token_manager, auth_bot_token):
+    super().__init__(dbconn)
+    self.client = client
+    self.auth_enable_groups = auth_enable_groups
+    self.token_manager = token_manager
+    self.auth_bot_token = auth_bot_token
+
   async def _get(self, request):
+    auth_str = request.query.get('auth', '')
+    user_id = None
+    if self.auth_bot_token and auth_str:
+      try:
+        padding = '=' * (4 - len(auth_str) % 4)
+        auth_str += padding
+        data = json.loads(base64.urlsafe_b64decode(auth_str).decode('utf-8'))
+        user_id = Verify_telegram_oauth(self.auth_bot_token, data)
+      except:
+        user_id = None
     groups = await self.dbconn.get_groups()
-    gs = [{
-      'group_id': str(g['group_id']),
-      'name': g['name'],
-      'pub_id': g['pub_id'],
-    } for g in groups]
+    gs = []
+    for g in groups:
+      if g['group_id'] not in self.auth_enable_groups:
+        gs.append({
+          'group_id': str(g['group_id']),
+          'name': g['name'],
+          'pub_id': g['pub_id'],
+        })
+      elif self.client and user_id:
+        try:
+          res = await self.client(functions.channels.GetParticipantRequest(
+              channel=g['group_id'],
+              participant=user_id
+          ))
+          gs.append({
+            'group_id': str(g['group_id']),
+            'name': g['name'],
+            'pub_id': g['pub_id'],
+            'token': self.token_manager.add_token(g['group_id']),
+          })
+        except UserNotParticipantError:
+          pass
+        except:
+          logger.exception('failed to get participant')
+
     gs.sort(key=lambda g: g['name'])
     return web.json_response({
       'groups': gs,
     })
 
 class NamesHandler(BaseHandler):
+  def __init__(self, dbconn, auth_enable_groups, token_manager):
+    super().__init__(dbconn)
+    self.auth_enable_groups = auth_enable_groups
+    self.token_manager = token_manager
+
   async def _get(self, request):
     group = int(request.query.get('g') or 0)
+    if self.auth_enable_groups and group == 0:
+      raise web.HTTPForbidden
+
+    if group in self.auth_enable_groups:
+      if not request.query.get('token'):
+        raise web.HTTPUnauthorized
+      if not self.token_manager.is_valid(group, request.query['token']):
+        raise web.HTTPForbidden
+
     q = request.query['q']
     names = await self.dbconn.find_names(group, q)
     return web.json_response({
@@ -187,12 +242,13 @@ def setup_app(
   origins = (),
   auth_enable_groups = (),
   token_manager = None,
+  auth_bot_token = None,
 ):
   app = web.Application()
   app['origins'] = origins
   app.router.add_get(f'{prefix}/search', SearchHandler(dbconn, auth_enable_groups, token_manager).get)
-  app.router.add_get(f'{prefix}/groups', GroupsHandler(dbconn).get)
-  app.router.add_get(f'{prefix}/names', NamesHandler(dbconn).get)
+  app.router.add_get(f'{prefix}/groups', GroupsHandler(dbconn, client, auth_enable_groups, token_manager, auth_bot_token).get)
+  app.router.add_get(f'{prefix}/names', NamesHandler(dbconn, auth_enable_groups, token_manager).get)
 
   if client:
     ah = AvatarHandler(client, cache_dir, default_avatar, ghost_avatar)

--- a/luoxu_plugins/auth/__init__.py
+++ b/luoxu_plugins/auth/__init__.py
@@ -1,0 +1,24 @@
+import logging
+import asyncio
+
+logger = logging.getLogger('luoxu_plugins.auth')
+
+
+async def register(indexer, client):
+    luoxu_web_url = indexer.config['plugin']['auth']['web_url']
+    enable_groups_ids = indexer.auth_enable_group_ids
+    ttl = int(indexer.config['telegram'].get('auth_expire', 3600))
+
+    async def auth(event):
+        chat = await event.get_chat()
+        if chat.id not in enable_groups_ids:
+            return
+        token = indexer.token_manager.add_token(chat.id)
+        url_message = await event.reply(f"{luoxu_web_url}?token={token}#g={chat.id}")
+        await asyncio.sleep(ttl)
+        try:
+            await url_message.delete()
+        except:
+            logger.warning('删除 url 消息失败')
+
+    indexer.add_msg_handler(auth, pattern='.*/luoxuurl$')

--- a/luoxu_plugins/auth/__init__.py
+++ b/luoxu_plugins/auth/__init__.py
@@ -14,7 +14,7 @@ async def register(indexer, client):
         if chat.id not in enable_groups_ids:
             return
         token = indexer.token_manager.add_token(chat.id)
-        url_message = await event.reply(f"{luoxu_web_url}?token={token}#g={chat.id}")
+        url_message = await event.reply(f"{luoxu_web_url}#token={token}&g={chat.id}")
         await asyncio.sleep(ttl)
         try:
             await url_message.delete()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "telethon",
   "aiohttp",
   "tomli; python_version<'3.11'",
+  "async-lru",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiohttp
 asyncpg
 telethon
+async-lru


### PR DESCRIPTION
通过 `telegram.auth_enable_groups` 配置非公开索引。
对于非公开索引，可以通过以下两种方式访问：
- 在对应群组内使用 `/luoxuurl` 获取访问链接（需要启用 `plugin.auth`)
- 在 luoxu-web 使用 Telegram 登录可以访问自己所在群组的非公开索引，需要配置一个 Telegram OAuth 需要用到的 bot，可以参考 https://core.telegram.org/widgets/login

luoxu-web 对应支持：https://github.com/lilydjwg/luoxu-web/pull/15